### PR TITLE
Fix parsing .dmis with one or more null png metadata entries

### DIFF
--- a/IconDiffBot/Core/DiffGenerator.cs
+++ b/IconDiffBot/Core/DiffGenerator.cs
@@ -29,7 +29,7 @@ namespace IconDiffBot.Core
 				return null;
 			var metadata = ImageMetadataReader.ReadMetadata(stream);
 			const string DmiHeader = "# BEGIN DMI";
-			var description = metadata.SelectMany(x => x.Tags).First(x => x.Description.Contains(DmiHeader)).Description;
+			var description = metadata.SelectMany(x => x.Tags).Select(x => x.Description).First(x => x != null && x.Contains(DmiHeader));
 			var startIndex = description.IndexOf(DmiHeader, StringComparison.InvariantCulture) + DmiHeader.Length;
 			var length = description.IndexOf("# END DMI", StringComparison.InvariantCulture) - startIndex;
 			return description.Substring(startIndex, length);


### PR DESCRIPTION
Fixes #33